### PR TITLE
Change to import fork

### DIFF
--- a/cumulative/cumulative.go
+++ b/cumulative/cumulative.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
-	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/telemetry"
 )
 
 // DeltaCalculator is used to create Count metrics from cumulative values.

--- a/cumulative/cumulative_test.go
+++ b/cumulative/cumulative_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/telemetry"
 )
 
 func Example() {

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/telemetry"
 )
 
 func databaseCall(collection string) {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
-module github.com/newrelic/newrelic-telemetry-sdk-go
+module github.com/newrelic-forks/newrelic-telemetry-sdk-go
+
+go 1.14
+
+require github.com/stretchr/testify v1.5.1

--- a/internal/json_writer.go
+++ b/internal/json_writer.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal/jsonx"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal/jsonx"
 )
 
 // JSONWriter is something that can write JSON to a buffer.

--- a/rate/rate.go
+++ b/rate/rate.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
-	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/telemetry"
 )
 
 // RateCalculator is used to create Gauge metrics from rate values.

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -2,7 +2,7 @@ package rate
 
 import (
 	"fmt"
-	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/telemetry"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -160,7 +160,7 @@ func (cfg *Config) metricURL() string {
 }
 
 // userAgent creates the User-Agent header version according to the spec here:
-// https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#user-agent
+// https://github.com/newrelic-forks/newrelic-telemetry-sdk-specs/blob/master/communication.md#user-agent
 func (cfg *Config) userAgent() string {
 	agent := "NewRelic-Go-TelemetrySDK/" + version
 	if "" != cfg.Product {

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 // Harvester aggregates and reports metrics and spans.

--- a/telemetry/harvester_test.go
+++ b/telemetry/harvester_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 // compactJSONString removes the whitespace from a JSON string.  This function

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 // Count is the metric type that counts the number of times an event occurred.

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 func TestMetrics(t *testing.T) {

--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 const (

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 // Span is a distributed tracing span.

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"github.com/newrelic-forks/newrelic-telemetry-sdk-go/internal"
 )
 
 func testSpanBatchJSON(t testing.TB, batch *spanBatch, expect string) {


### PR DESCRIPTION
Update imports to reference current fork repository. Fixes compile errors if is integrated into other repos.

Should be updated before fork is merge